### PR TITLE
Offer to link a new activity with its planned training on load

### DIFF
--- a/src/components/journal/ActivityOption.tsx
+++ b/src/components/journal/ActivityOption.tsx
@@ -1,0 +1,35 @@
+import { format } from "date-fns";
+
+import { getActiveDateLocale } from "~/i18n/activeDateLocale";
+import { sportTypeLabel } from "~/i18n/labels";
+import { useT } from "~/i18n/useT";
+import { getSportConfig } from "~/utils/sportConfig";
+
+/** Minimal activity shape needed to label an activity in a link/pick UI. */
+export interface ActivityOptionData {
+  type: string;
+  name: string;
+  startDateLocal: string;
+}
+
+/**
+ * Coloured sport icon + `EEE d MMM · name` for one activity. Shared by the Mark
+ * done picker and the link prompt so a matched activity reads the same either
+ * way; falls back to the sport label for activities left unnamed on Strava.
+ */
+export function ActivityOption({ activity }: { activity: ActivityOptionData }) {
+  const t = useT();
+  const config = getSportConfig(activity.type);
+  const Icon = config.icon;
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <Icon className="size-4 shrink-0" style={{ color: config.color }} />
+      <span className="truncate">
+        {format(new Date(activity.startDateLocal), "EEE d MMM", {
+          locale: getActiveDateLocale(),
+        })}{" "}
+        · {activity.name || sportTypeLabel(activity.type, t)}
+      </span>
+    </span>
+  );
+}

--- a/src/components/journal/LinkActivityPrompt.tsx
+++ b/src/components/journal/LinkActivityPrompt.tsx
@@ -1,0 +1,191 @@
+import * as React from "react";
+
+import { format } from "date-fns";
+
+import type { PlannedTraining } from "@server/db/types";
+
+import { Button } from "~/components/ui/button";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "~/components/ui/responsive-dialog";
+import type { NewActivity } from "~/hooks/useNewActivityMatches";
+import { useNewActivityMatches } from "~/hooks/useNewActivityMatches";
+import { getActiveDateLocale } from "~/i18n/activeDateLocale";
+import { useT } from "~/i18n/useT";
+import { formatCompactDuration } from "~/utils/format";
+import { getSportConfig } from "~/utils/sportConfig";
+import { trpc } from "~/utils/trpc";
+
+import { ActivityOption } from "./ActivityOption";
+
+/** One plan ↔ activity pairing, with its own Link button and error state. */
+function MatchRow({
+  athleteId,
+  plan,
+  activity,
+}: {
+  athleteId: number;
+  plan: PlannedTraining;
+  activity: NewActivity;
+}) {
+  const t = useT();
+  const utils = trpc.useUtils();
+  const config = getSportConfig(plan.sportType);
+  const Icon = config.icon;
+
+  const markDoneMut = trpc.plannedTrainings.markDone.useMutation({
+    onSuccess: () => {
+      void utils.plannedTrainings.list.invalidate();
+      void utils.activities.list.invalidate();
+    },
+  });
+
+  return (
+    <div className="border-border flex flex-col gap-2 rounded-md border p-3">
+      <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+        <Icon className="size-4 shrink-0" style={{ color: config.color }} />
+        <span className="truncate">{plan.title}</span>
+      </div>
+      <p className="text-muted-foreground text-xs">
+        {t("journal.linkPrompt.plannedFor", {
+          date: format(new Date(plan.plannedDate), "EEE d MMM", {
+            locale: getActiveDateLocale(),
+          }),
+          duration: formatCompactDuration(plan.durationSeconds, {
+            subHour: "min",
+          }),
+        })}
+      </p>
+      <div className="text-muted-foreground flex items-center gap-2 text-sm">
+        <span aria-hidden>↳</span>
+        <ActivityOption activity={activity} />
+      </div>
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          disabled={markDoneMut.isPending || markDoneMut.isSuccess}
+          onClick={() =>
+            markDoneMut.mutate({
+              athleteId,
+              id: plan.id,
+              stravaId: activity.stravaId,
+            })
+          }
+        >
+          {markDoneMut.isPending
+            ? t("journal.dialog.linking")
+            : markDoneMut.isSuccess
+              ? t("journal.linkPrompt.linked")
+              : t("journal.linkPrompt.link")}
+        </Button>
+      </div>
+      {markDoneMut.isError && (
+        <p className="text-destructive text-xs">
+          {t("journal.dialog.markDoneError")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Offers to reconcile planned trainings with activities imported since the last
+ * visit, on load, anywhere in the app — the Journal's Mark done picker only
+ * helps once you already suspect a match is waiting.
+ *
+ * Closing it by any route (linking, "Not now", Escape, backdrop) acknowledges
+ * the whole batch: having been shown the prompt once is the point, and re-asking
+ * on every load until the athlete formally answers would be nagging. Anything
+ * skipped stays reachable from the Journal.
+ */
+export function LinkActivityPrompt() {
+  const t = useT();
+  const { athleteId, pairs, watermark, isReady } = useNewActivityMatches();
+  const utils = trpc.useUtils();
+  const acknowledgeMut =
+    trpc.plannedTrainings.acknowledgeNewActivities.useMutation({
+      onSuccess: () => {
+        void utils.plannedTrainings.newActivities.invalidate();
+      },
+    });
+
+  const [open, setOpen] = React.useState(false);
+  // What the prompt was opened with. Snapshotted rather than read live because
+  // `pairs` empties out underneath it — linking invalidates the plan list, and
+  // acknowledging on close invalidates the activity list while base-ui is still
+  // animating the popup out. The watermark is frozen alongside so the athlete
+  // acknowledges exactly the batch they were shown, not a newer one that a
+  // background refetch slipped in.
+  const [batch, setBatch] = React.useState<{
+    pairs: typeof pairs;
+    watermark: number;
+  } | null>(null);
+  // Latches so the prompt opens at most once per session.
+  const shown = React.useRef(false);
+
+  React.useEffect(() => {
+    if (shown.current || !isReady || pairs.length === 0 || watermark == null) {
+      return;
+    }
+    shown.current = true;
+    setBatch({ pairs, watermark });
+    setOpen(true);
+  }, [isReady, pairs, watermark]);
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next && athleteId != null && batch != null) {
+      acknowledgeMut.mutate({ athleteId, watermark: batch.watermark });
+    }
+  };
+
+  if (athleteId == null) {
+    return null;
+  }
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveDialogContent>
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>
+            {t("journal.linkPrompt.title")}
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            {t("journal.linkPrompt.description", {
+              count: batch?.pairs.length ?? 0,
+            })}
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <div className="flex flex-col gap-3">
+          {batch?.pairs.map(({ plan, activity }) => (
+            <MatchRow
+              key={plan.id}
+              athleteId={athleteId}
+              plan={plan}
+              activity={activity}
+            />
+          ))}
+          <p className="text-muted-foreground text-xs">
+            {t("journal.dialog.markDoneRenameHint")}
+          </p>
+        </div>
+        <ResponsiveDialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            {t("journal.linkPrompt.notNow")}
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/src/components/journal/LinkActivityPrompt.tsx
+++ b/src/components/journal/LinkActivityPrompt.tsx
@@ -42,6 +42,9 @@ function MatchRow({
     onSuccess: () => {
       void utils.plannedTrainings.list.invalidate();
       void utils.activities.list.invalidate();
+      // The activity is now spoken for. Without this the Journal's Mark done
+      // picker keeps offering it from cache and would link it to a second plan.
+      void utils.plannedTrainings.linkedActivityIds.invalidate();
     },
   });
 
@@ -88,10 +91,33 @@ function MatchRow({
       </div>
       {markDoneMut.isError && (
         <p className="text-destructive text-xs">
-          {t("journal.dialog.markDoneError")}
+          {t(
+            markDoneMut.error.data?.code === "CONFLICT"
+              ? "journal.dialog.markDoneConflict"
+              : "journal.dialog.markDoneError",
+          )}
         </p>
       )}
     </div>
+  );
+}
+
+/**
+ * Whether grabbing the focus trap right now would interrupt something. The prompt
+ * waits on two queries, so it opens a few hundred milliseconds after the page is
+ * interactive — easily late enough to land mid-word in the Journal's title field,
+ * or on top of a dialog the athlete has already opened.
+ */
+function wouldInterrupt(): boolean {
+  if (document.querySelector('[role="dialog"]') != null) {
+    return true;
+  }
+  const active = document.activeElement;
+  return (
+    active instanceof HTMLInputElement ||
+    active instanceof HTMLTextAreaElement ||
+    active instanceof HTMLSelectElement ||
+    (active instanceof HTMLElement && active.isContentEditable)
   );
 }
 
@@ -134,9 +160,20 @@ export function LinkActivityPrompt() {
     if (shown.current || !isReady || pairs.length === 0 || watermark == null) {
       return;
     }
-    shown.current = true;
-    setBatch({ pairs, watermark });
-    setOpen(true);
+    // A frame later, so the focus check reads a settled DOM rather than the one
+    // mid-update from the render the queries settling just caused.
+    const frame = requestAnimationFrame(() => {
+      // Bailing without latching `shown`: nothing has been acknowledged, so the
+      // prompt just comes back on the next load rather than fighting for the
+      // caret now. A retry loop isn't worth it for a once-a-day prompt.
+      if (wouldInterrupt()) {
+        return;
+      }
+      shown.current = true;
+      setBatch({ pairs, watermark });
+      setOpen(true);
+    });
+    return () => cancelAnimationFrame(frame);
   }, [isReady, pairs, watermark]);
 
   const handleOpenChange = (next: boolean) => {

--- a/src/components/journal/PlannedTrainingDialog.tsx
+++ b/src/components/journal/PlannedTrainingDialog.tsx
@@ -108,6 +108,9 @@ function PlannedTrainingForm({ athleteId, state, onClose }: FormProps) {
     onSuccess: () => {
       void invalidateList();
       void utils.activities.list.invalidate();
+      // The activity is now spoken for; without this the picker keeps offering it
+      // from cache for the next plan opened.
+      void utils.plannedTrainings.linkedActivityIds.invalidate();
       onClose();
     },
   });
@@ -255,12 +258,8 @@ function MarkDoneSection({
   // day). Anything outside those criteria, or already linked, is dropped.
   const { groups, byStravaId } = React.useMemo(() => {
     const linked = new Set(linkedActivityIds ?? []);
-    const plan = {
-      plannedDate: training.plannedDate,
-      sportType: training.sportType,
-    };
-    const plannedCategory = getSportConfig(plan.sportType).category;
-    const plannedDate = new Date(`${dayKey(plan.plannedDate)}T00:00:00`);
+    const plannedCategory = getSportConfig(training.sportType).category;
+    const plannedDate = new Date(`${dayKey(training.plannedDate)}T00:00:00`);
 
     const perfect: string[] = [];
     const other: string[] = [];
@@ -275,7 +274,7 @@ function MarkDoneSection({
       }
       const activityDay = dayKey(a.startDateLocal);
       const stravaId = String(a.stravaId);
-      if (isPerfectMatch(plan, a)) {
+      if (isPerfectMatch(training, a)) {
         perfect.push(stravaId);
         map.set(stravaId, a);
       } else if (
@@ -299,13 +298,7 @@ function MarkDoneSection({
       result.push({ value: t("journal.dialog.otherMatches"), items: other });
     }
     return { groups: result, byStravaId: map };
-  }, [
-    activities,
-    linkedActivityIds,
-    training.sportType,
-    training.plannedDate,
-    t,
-  ]);
+  }, [activities, linkedActivityIds, training, t]);
 
   return (
     <div className="border-border flex flex-col gap-2 border-t pt-4">
@@ -391,7 +384,11 @@ function MarkDoneSection({
       )}
       {markDoneMut.isError && (
         <p className="text-destructive text-sm">
-          {t("journal.dialog.markDoneError")}
+          {t(
+            markDoneMut.error.data?.code === "CONFLICT"
+              ? "journal.dialog.markDoneConflict"
+              : "journal.dialog.markDoneError",
+          )}
         </p>
       )}
     </div>

--- a/src/components/journal/PlannedTrainingDialog.tsx
+++ b/src/components/journal/PlannedTrainingDialog.tsx
@@ -36,6 +36,10 @@ import { useT } from "~/i18n/useT";
 import { PLANNABLE_SPORT_TYPES, getSportConfig } from "~/utils/sportConfig";
 import { trpc } from "~/utils/trpc";
 
+import type { ActivityOptionData } from "./ActivityOption";
+import { ActivityOption } from "./ActivityOption";
+import { dayKey, isPerfectMatch } from "./perfectMatch";
+
 const NATIVE_INPUT_CLASS =
   "border-input bg-background ring-offset-background focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none";
 
@@ -44,11 +48,6 @@ export type PlannerDialogState =
   | { mode: "create"; date: Date }
   | { mode: "edit"; training: PlannedTraining }
   | null;
-
-/** Local day key (yyyy-MM-dd) of a floating-local ISO datetime string. */
-function dayKey(isoLocal: string): string {
-  return isoLocal.slice(0, 10);
-}
 
 interface FormProps {
   athleteId: number;
@@ -227,31 +226,6 @@ function PlannedTrainingForm({ athleteId, state, onClose }: FormProps) {
   );
 }
 
-/** Minimal activity shape the mark-done picker needs to label an option. */
-interface MarkDoneActivity {
-  type: string;
-  name: string;
-  startDateLocal: string;
-}
-
-/** Coloured sport icon + date · name for a mark-done option / value. */
-function ActivityOption({ activity }: { activity: MarkDoneActivity }) {
-  const t = useT();
-  const config = getSportConfig(activity.type);
-  const Icon = config.icon;
-  return (
-    <span className="flex min-w-0 items-center gap-2">
-      <Icon className="size-4 shrink-0" style={{ color: config.color }} />
-      <span className="truncate">
-        {format(new Date(activity.startDateLocal), "EEE d MMM", {
-          locale: getActiveDateLocale(),
-        })}{" "}
-        · {activity.name || sportTypeLabel(activity.type, t)}
-      </span>
-    </span>
-  );
-}
-
 /** Group shape consumed by the mark-done Combobox (items are stravaId strings). */
 interface ActivityGroup {
   value: string;
@@ -281,13 +255,16 @@ function MarkDoneSection({
   // day). Anything outside those criteria, or already linked, is dropped.
   const { groups, byStravaId } = React.useMemo(() => {
     const linked = new Set(linkedActivityIds ?? []);
-    const plannedCategory = getSportConfig(training.sportType).category;
-    const plannedDay = dayKey(training.plannedDate);
-    const plannedDate = new Date(`${plannedDay}T00:00:00`);
+    const plan = {
+      plannedDate: training.plannedDate,
+      sportType: training.sportType,
+    };
+    const plannedCategory = getSportConfig(plan.sportType).category;
+    const plannedDate = new Date(`${dayKey(plan.plannedDate)}T00:00:00`);
 
     const perfect: string[] = [];
     const other: string[] = [];
-    const map = new Map<string, MarkDoneActivity>();
+    const map = new Map<string, ActivityOptionData>();
 
     for (const a of activities ?? []) {
       if (linked.has(a.id)) {
@@ -296,9 +273,9 @@ function MarkDoneSection({
       if (getSportConfig(a.type).category !== plannedCategory) {
         continue;
       }
-      const activityDay = a.startDateLocal.slice(0, 10);
+      const activityDay = dayKey(a.startDateLocal);
       const stravaId = String(a.stravaId);
-      if (activityDay === plannedDay) {
+      if (isPerfectMatch(plan, a)) {
         perfect.push(stravaId);
         map.set(stravaId, a);
       } else if (

--- a/src/components/journal/perfectMatch.test.ts
+++ b/src/components/journal/perfectMatch.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { isPerfectMatch, pairPerfectMatches } from "./perfectMatch";
+
+const plan = (plannedDate: string, sportType: string) => ({
+  plannedDate,
+  sportType,
+});
+const activity = (startDateLocal: string, type: string) => ({
+  startDateLocal,
+  type,
+});
+
+describe("isPerfectMatch", () => {
+  it("matches same day, same sport", () => {
+    expect(
+      isPerfectMatch(
+        plan("2026-03-04T07:00:00", "Ride"),
+        activity("2026-03-04T18:22:11", "Ride"),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores the time of day", () => {
+    expect(
+      isPerfectMatch(
+        plan("2026-03-04T07:00:00", "Run"),
+        activity("2026-03-04T23:59:59", "Run"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a different day", () => {
+    expect(
+      isPerfectMatch(
+        plan("2026-03-04T07:00:00", "Ride"),
+        activity("2026-03-05T07:00:00", "Ride"),
+      ),
+    ).toBe(false);
+  });
+
+  it("matches across types within a sport category", () => {
+    expect(
+      isPerfectMatch(
+        plan("2026-03-04T07:00:00", "Ride"),
+        activity("2026-03-04T07:00:00", "VirtualRide"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a different sport category", () => {
+    expect(
+      isPerfectMatch(
+        plan("2026-03-04T07:00:00", "Ride"),
+        activity("2026-03-04T07:00:00", "Run"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("pairPerfectMatches", () => {
+  it("returns nothing for empty inputs", () => {
+    expect(pairPerfectMatches([], [])).toEqual([]);
+    expect(
+      pairPerfectMatches([plan("2026-03-04T07:00:00", "Ride")], []),
+    ).toEqual([]);
+    expect(
+      pairPerfectMatches([], [activity("2026-03-04T07:00:00", "Ride")]),
+    ).toEqual([]);
+  });
+
+  it("pairs each plan with its matching activity", () => {
+    const ride = plan("2026-03-04T07:00:00", "Ride");
+    const run = plan("2026-03-05T07:00:00", "Run");
+    const rideActivity = activity("2026-03-04T18:00:00", "Ride");
+    const runActivity = activity("2026-03-05T12:00:00", "Run");
+
+    expect(
+      pairPerfectMatches([run, ride], [runActivity, rideActivity]),
+    ).toEqual([
+      { plan: ride, activity: rideActivity },
+      { plan: run, activity: runActivity },
+    ]);
+  });
+
+  it("never gives one activity to two plans", () => {
+    const first = plan("2026-03-04T07:00:00", "Ride");
+    const second = plan("2026-03-04T17:00:00", "Ride");
+    const only = activity("2026-03-04T18:00:00", "Ride");
+
+    const pairs = pairPerfectMatches([first, second], [only]);
+
+    expect(pairs).toEqual([{ plan: first, activity: only }]);
+  });
+
+  it("never gives one plan two activities", () => {
+    const single = plan("2026-03-04T07:00:00", "Ride");
+    const morning = activity("2026-03-04T08:00:00", "Ride");
+    const evening = activity("2026-03-04T18:00:00", "Ride");
+
+    const pairs = pairPerfectMatches([single], [evening, morning]);
+
+    expect(pairs).toEqual([{ plan: single, activity: morning }]);
+  });
+
+  it("leaves unmatched plans and activities out", () => {
+    const matched = plan("2026-03-04T07:00:00", "Ride");
+    const unmatched = plan("2026-03-06T07:00:00", "Swim");
+    const rideActivity = activity("2026-03-04T18:00:00", "Ride");
+    const strayActivity = activity("2026-03-07T09:00:00", "Run");
+
+    expect(
+      pairPerfectMatches([matched, unmatched], [rideActivity, strayActivity]),
+    ).toEqual([{ plan: matched, activity: rideActivity }]);
+  });
+});

--- a/src/components/journal/perfectMatch.test.ts
+++ b/src/components/journal/perfectMatch.test.ts
@@ -56,6 +56,29 @@ describe("isPerfectMatch", () => {
       ),
     ).toBe(false);
   });
+
+  it("requires the exact type in the catch-all 'other' category", () => {
+    // Both sides resolve to `other`: `AlpineSki` is configured that way and
+    // `Yoga` has no config at all. Equal categories must not be enough here.
+    expect(
+      isPerfectMatch(
+        plan("2026-03-04T07:00:00", "AlpineSki"),
+        activity("2026-03-04T07:00:00", "Yoga"),
+      ),
+    ).toBe(false);
+    expect(
+      isPerfectMatch(
+        plan("2026-03-04T07:00:00", "AlpineSki"),
+        activity("2026-03-04T07:00:00", "NordicSki"),
+      ),
+    ).toBe(false);
+    expect(
+      isPerfectMatch(
+        plan("2026-03-04T07:00:00", "AlpineSki"),
+        activity("2026-03-04T07:00:00", "AlpineSki"),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("pairPerfectMatches", () => {
@@ -93,14 +116,28 @@ describe("pairPerfectMatches", () => {
     expect(pairs).toEqual([{ plan: first, activity: only }]);
   });
 
-  it("never gives one plan two activities", () => {
-    const single = plan("2026-03-04T07:00:00", "Ride");
-    const morning = activity("2026-03-04T08:00:00", "Ride");
-    const evening = activity("2026-03-04T18:00:00", "Ride");
+  it("declines to choose when a plan matches two activities", () => {
+    // The commute-plus-training-ride day. "Perfect match" knows nothing about
+    // time of day or duration, so there is no basis to prefer either ride —
+    // guessing would rename the wrong one on Strava.
+    const single = plan("2026-03-04T18:00:00", "Ride");
+    const commute = activity("2026-03-04T08:00:00", "Ride");
+    const intervals = activity("2026-03-04T18:30:00", "Ride");
 
-    const pairs = pairPerfectMatches([single], [evening, morning]);
+    expect(pairPerfectMatches([single], [intervals, commute])).toEqual([]);
+  });
 
-    expect(pairs).toEqual([{ plan: single, activity: morning }]);
+  it("leaves a two-plans-two-rides day entirely to the Journal picker", () => {
+    // Both plans match both rides, so neither pairing is forced. Pairing them off
+    // in time order looks tempting and is only ever right by luck.
+    const morningPlan = plan("2026-03-04T08:00:00", "Ride");
+    const eveningPlan = plan("2026-03-04T18:00:00", "Ride");
+    const first = activity("2026-03-04T08:10:00", "Ride");
+    const second = activity("2026-03-04T18:10:00", "Ride");
+
+    expect(
+      pairPerfectMatches([morningPlan, eveningPlan], [first, second]),
+    ).toEqual([]);
   });
 
   it("leaves unmatched plans and activities out", () => {

--- a/src/components/journal/perfectMatch.ts
+++ b/src/components/journal/perfectMatch.ts
@@ -1,0 +1,76 @@
+import { getSportConfig } from "~/utils/sportConfig";
+
+/**
+ * A "perfect match" is the Journal's notion of a planned training and a Strava
+ * activity that plainly fulfil each other: same calendar day, same broad sport
+ * category. It powers both the "Perfect matches" group of the Mark done picker
+ * and the prompt that offers to link a newly imported activity on load — hence
+ * living here rather than in either consumer, so the two can never drift.
+ *
+ * Category, not exact type, so a `VirtualRide` fulfils a planned `Ride`.
+ */
+
+/** Local day key (yyyy-MM-dd) of a floating-local ISO datetime string. */
+export function dayKey(isoLocal: string): string {
+  return isoLocal.slice(0, 10);
+}
+
+/** The plan fields the match rule reads. */
+export interface MatchablePlan {
+  plannedDate: string;
+  sportType: string;
+}
+
+/** The activity fields the match rule reads. */
+export interface MatchableActivity {
+  startDateLocal: string;
+  type: string;
+}
+
+/** Same calendar day + same sport category. */
+export function isPerfectMatch(
+  plan: MatchablePlan,
+  activity: MatchableActivity,
+): boolean {
+  return (
+    dayKey(plan.plannedDate) === dayKey(activity.startDateLocal) &&
+    getSportConfig(plan.sportType).category ===
+      getSportConfig(activity.type).category
+  );
+}
+
+/**
+ * Greedy 1:1 pairing: walking both sides in chronological order, each plan takes
+ * the earliest activity that perfectly matches it and isn't already spoken for.
+ *
+ * The 1:1 constraint matters because linking is destructive (it renames the
+ * activity on Strava) and an activity must never end up claimed by two plans. On
+ * an ambiguous day — two plans, two matching rides — this offers one pairing per
+ * plan rather than guessing among the alternatives; anything it can't pair off
+ * is left to the Journal's Mark done picker, where the athlete chooses manually.
+ */
+export function pairPerfectMatches<
+  P extends MatchablePlan,
+  A extends MatchableActivity,
+>(plans: readonly P[], activities: readonly A[]): { plan: P; activity: A }[] {
+  const sortedPlans = [...plans].sort((a, b) =>
+    a.plannedDate.localeCompare(b.plannedDate),
+  );
+  const sortedActivities = [...activities].sort((a, b) =>
+    a.startDateLocal.localeCompare(b.startDateLocal),
+  );
+  const claimed = new Set<A>();
+  const pairs: { plan: P; activity: A }[] = [];
+
+  for (const plan of sortedPlans) {
+    const activity = sortedActivities.find(
+      (candidate) => !claimed.has(candidate) && isPerfectMatch(plan, candidate),
+    );
+    if (activity) {
+      claimed.add(activity);
+      pairs.push({ plan, activity });
+    }
+  }
+
+  return pairs;
+}

--- a/src/components/journal/perfectMatch.ts
+++ b/src/components/journal/perfectMatch.ts
@@ -7,7 +7,9 @@ import { getSportConfig } from "~/utils/sportConfig";
  * and the prompt that offers to link a newly imported activity on load — hence
  * living here rather than in either consumer, so the two can never drift.
  *
- * Category, not exact type, so a `VirtualRide` fulfils a planned `Ride`.
+ * Category, not exact type, so a `VirtualRide` fulfils a planned `Ride` — except
+ * in the `other` category, which is `sportConfig`'s fallback for every type it
+ * has no entry for and so groups nothing meaningful together.
  */
 
 /** Local day key (yyyy-MM-dd) of a floating-local ISO datetime string. */
@@ -32,22 +34,37 @@ export function isPerfectMatch(
   plan: MatchablePlan,
   activity: MatchableActivity,
 ): boolean {
-  return (
-    dayKey(plan.plannedDate) === dayKey(activity.startDateLocal) &&
-    getSportConfig(plan.sportType).category ===
-      getSportConfig(activity.type).category
-  );
+  if (dayKey(plan.plannedDate) !== dayKey(activity.startDateLocal)) {
+    return false;
+  }
+  const planCategory = getSportConfig(plan.sportType).category;
+  if (planCategory !== getSportConfig(activity.type).category) {
+    return false;
+  }
+  // `other` is the bucket every type `sportConfig` has no entry for, so landing
+  // in it together means nothing — a Yoga session and a planned `AlpineSki` are
+  // both "other". Only the exact type tells them apart there.
+  if (planCategory === "other") {
+    return plan.sportType === activity.type;
+  }
+  return true;
 }
 
 /**
- * Greedy 1:1 pairing: walking both sides in chronological order, each plan takes
- * the earliest activity that perfectly matches it and isn't already spoken for.
+ * Strictly unambiguous 1:1 pairing: a plan is paired only when exactly one
+ * not-yet-claimed activity perfectly matches it.
  *
- * The 1:1 constraint matters because linking is destructive (it renames the
- * activity on Strava) and an activity must never end up claimed by two plans. On
- * an ambiguous day — two plans, two matching rides — this offers one pairing per
- * plan rather than guessing among the alternatives; anything it can't pair off
- * is left to the Journal's Mark done picker, where the athlete chooses manually.
+ * Linking is destructive (it renames the activity on Strava), so this never
+ * guesses. Neither side of a "perfect match" carries enough signal to choose
+ * between alternatives: the rule is day + sport category, which says nothing
+ * about time of day or duration — so on a day with a bike commute *and* an
+ * interval session, "the earlier one" would be exactly the wrong answer as often
+ * as the right one. Plans are walked in chronological order only to make the
+ * outcome deterministic when several compete for one activity: the earliest plan
+ * claims it, the rest are left alone.
+ *
+ * Everything it declines to pair stays reachable from the Journal's Mark done
+ * picker, which shows all the candidates and lets the athlete choose.
  */
 export function pairPerfectMatches<
   P extends MatchablePlan,
@@ -56,20 +73,18 @@ export function pairPerfectMatches<
   const sortedPlans = [...plans].sort((a, b) =>
     a.plannedDate.localeCompare(b.plannedDate),
   );
-  const sortedActivities = [...activities].sort((a, b) =>
-    a.startDateLocal.localeCompare(b.startDateLocal),
-  );
   const claimed = new Set<A>();
   const pairs: { plan: P; activity: A }[] = [];
 
   for (const plan of sortedPlans) {
-    const activity = sortedActivities.find(
+    const candidates = activities.filter(
       (candidate) => !claimed.has(candidate) && isPerfectMatch(plan, candidate),
     );
-    if (activity) {
-      claimed.add(activity);
-      pairs.push({ plan, activity });
+    if (candidates.length !== 1) {
+      continue;
     }
+    claimed.add(candidates[0]);
+    pairs.push({ plan, activity: candidates[0] });
   }
 
   return pairs;

--- a/src/components/layouts/LoggedInLayout/LoggedInLayout.tsx
+++ b/src/components/layouts/LoggedInLayout/LoggedInLayout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
+import { LinkActivityPrompt } from "~/components/journal/LinkActivityPrompt";
 import { DismissedHintsProvider } from "~/hooks/useDismissedHints";
 import { ErgModeProvider } from "~/hooks/useErgMode";
 import { ExplorerTilesProvider } from "~/hooks/useExplorerTilesToggle";
@@ -52,6 +53,9 @@ export const LoggedInLayout = (props: LoggedInLayoutProps) => {
                   </main>
                   <MobileBottomBar />
                 </div>
+                {/* Opens itself on load when a newly imported activity matches a
+                    planned training — the app's only self-opening dialog. */}
+                <LinkActivityPrompt />
               </ErgModeProvider>
             </DismissedHintsProvider>
           </RiderSettingsProvider>

--- a/src/hooks/useNewActivityMatches.ts
+++ b/src/hooks/useNewActivityMatches.ts
@@ -1,0 +1,56 @@
+import * as React from "react";
+
+import type { PlannedTraining } from "@server/db/types";
+
+import { pairPerfectMatches } from "~/components/journal/perfectMatch";
+import { trpc } from "~/utils/trpc";
+
+import { useAthleteId } from "./useAthleteId";
+
+/** The activity projection `plannedTrainings.newActivities` returns. */
+export interface NewActivity {
+  id: number;
+  stravaId: number;
+  type: string;
+  name: string;
+  startDateLocal: string;
+}
+
+/**
+ * Planned trainings that a just-imported activity perfectly matches — the input
+ * to the prompt that offers to link them on load.
+ *
+ * The plan list is fetched unscoped rather than reusing the Journal's
+ * range-scoped `list` query: a match can sit outside whichever weeks the Journal
+ * happens to be showing (or the athlete may not be on the Journal at all).
+ * Planned trainings are few and `list` already filters to `status = "planned"`
+ * server-side, so this is a cheap, separately cached call.
+ */
+export function useNewActivityMatches() {
+  const athleteId = useAthleteId();
+
+  const newActivities = trpc.plannedTrainings.newActivities.useQuery(
+    { athleteId: athleteId! },
+    { enabled: athleteId != null },
+  );
+  const plans = trpc.plannedTrainings.list.useQuery(
+    { athleteId: athleteId! },
+    { enabled: athleteId != null },
+  );
+
+  const pairs = React.useMemo(
+    () =>
+      pairPerfectMatches<PlannedTraining, NewActivity>(
+        plans.data ?? [],
+        newActivities.data?.activities ?? [],
+      ),
+    [plans.data, newActivities.data],
+  );
+
+  return {
+    athleteId,
+    pairs,
+    watermark: newActivities.data?.watermark ?? null,
+    isReady: newActivities.isSuccess && plans.isSuccess,
+  };
+}

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -163,6 +163,8 @@ const en = {
       markDone: "Mark done",
       markDoneError:
         "Couldn't update the activity on Strava. Please try again.",
+      markDoneConflict:
+        "This activity is already linked to another planned training.",
     },
     linkPrompt: {
       title: "Did you complete this training?",

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -164,6 +164,17 @@ const en = {
       markDoneError:
         "Couldn't update the activity on Strava. Please try again.",
     },
+    linkPrompt: {
+      title: "Did you complete this training?",
+      description: {
+        one: "A new activity matches one of your planned trainings.",
+        other: "New activities match {count} of your planned trainings.",
+      },
+      plannedFor: "Planned for {date} · {duration}",
+      link: "Link",
+      linked: "Linked",
+      notNow: "Not now",
+    },
   },
   stats: {
     movingTime: "Moving Time",

--- a/src/i18n/messages/fr.ts
+++ b/src/i18n/messages/fr.ts
@@ -164,6 +164,8 @@ const fr: Messages = {
       markDone: "Marquer comme faite",
       markDoneError:
         "Impossible de mettre à jour l'activité sur Strava. Veuillez réessayer.",
+      markDoneConflict:
+        "Cette activité est déjà liée à une autre séance planifiée.",
     },
     linkPrompt: {
       title: "Avez-vous fait cette séance ?",

--- a/src/i18n/messages/fr.ts
+++ b/src/i18n/messages/fr.ts
@@ -165,6 +165,18 @@ const fr: Messages = {
       markDoneError:
         "Impossible de mettre à jour l'activité sur Strava. Veuillez réessayer.",
     },
+    linkPrompt: {
+      title: "Avez-vous fait cette séance ?",
+      description: {
+        one: "Une nouvelle activité correspond à une de vos séances planifiées.",
+        other:
+          "De nouvelles activités correspondent à {count} de vos séances planifiées.",
+      },
+      plannedFor: "Prévue le {date} · {duration}",
+      link: "Lier",
+      linked: "Liée",
+      notNow: "Plus tard",
+    },
   },
   stats: {
     movingTime: "Temps actif",

--- a/src/server/db/migrations/0020_bizarre_shard.sql
+++ b/src/server/db/migrations/0020_bizarre_shard.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "athletes" ADD COLUMN "last_seen_activity_id" integer;

--- a/src/server/db/migrations/0021_handy_blue_blade.sql
+++ b/src/server/db/migrations/0021_handy_blue_blade.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "activities_athlete_id_idx" ON "activities" USING btree ("athlete","id");

--- a/src/server/db/migrations/meta/0020_snapshot.json
+++ b/src/server/db/migrations/meta/0020_snapshot.json
@@ -1,0 +1,1619 @@
+{
+  "id": "9a8576b2-19e2-421d-897c-fbcb3efe63cb",
+  "prevId": "349aec5e-ddfa-4b03-bc1a-cafdcfa4e7ce",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "strava_id": {
+          "name": "strava_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date_local": {
+          "name": "start_date_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_elevation_gain": {
+          "name": "total_elevation_gain",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_speed": {
+          "name": "average_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_watts": {
+          "name": "average_watts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_cadence": {
+          "name": "average_cadence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_heartrate": {
+          "name": "average_heartrate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_heartrate": {
+          "name": "max_heartrate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_speed": {
+          "name": "max_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_watts": {
+          "name": "max_watts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_average_watts": {
+          "name": "weighted_average_watts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilojoules": {
+          "name": "kilojoules",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moving_time": {
+          "name": "moving_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elapsed_time": {
+          "name": "elapsed_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_polyline": {
+          "name": "map_polyline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "are_streams_loaded": {
+          "name": "are_streams_loaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stream_fetch_attempts": {
+          "name": "stream_fetch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hrss": {
+          "name": "hrss",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tss": {
+          "name": "tss",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commute": {
+          "name": "commute",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perceived_exertion": {
+          "name": "perceived_exertion",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_note": {
+          "name": "private_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "power_bests": {
+          "name": "power_bests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_efforts": {
+          "name": "speed_efforts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "biggest_climb": {
+          "name": "biggest_climb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartrate_bests": {
+          "name": "heartrate_bests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "laps": {
+          "name": "laps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "are_best_efforts_loaded": {
+          "name": "are_best_efforts_loaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "best_effort_fetch_attempts": {
+          "name": "best_effort_fetch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "activities_strava_id_idx": {
+          "name": "activities_strava_id_idx",
+          "columns": [
+            {
+              "expression": "strava_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_athlete_idx": {
+          "name": "activities_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_athlete_start_date_idx": {
+          "name": "activities_athlete_start_date_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_athlete_streams_loaded_idx": {
+          "name": "activities_athlete_streams_loaded_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "are_streams_loaded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_athlete_best_efforts_idx": {
+          "name": "activities_athlete_best_efforts_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "are_best_efforts_loaded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activities_athlete_athletes_id_fk": {
+          "name": "activities_athlete_athletes_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_streams": {
+      "name": "activity_streams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_type": {
+          "name": "series_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_size": {
+          "name": "original_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_streams_activity_id_idx": {
+          "name": "activity_streams_activity_id_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_streams_activity_id_type_idx": {
+          "name": "activity_streams_activity_id_type_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_streams_activity_id_activities_id_fk": {
+          "name": "activity_streams_activity_id_activities_id_fk",
+          "tableFrom": "activity_streams",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.athlete_stats": {
+      "name": "athlete_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "athlete_stats_athlete_idx": {
+          "name": "athlete_stats_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "athlete_stats_athlete_athletes_id_fk": {
+          "name": "athlete_stats_athlete_athletes_id_fk",
+          "tableFrom": "athlete_stats",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.athletes": {
+      "name": "athletes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "strava_athlete_id": {
+          "name": "strava_athlete_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en-GB'"
+        },
+        "calendar_token": {
+          "name": "calendar_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_activity_id": {
+          "name": "last_seen_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "athletes_strava_id_idx": {
+          "name": "athletes_strava_id_idx",
+          "columns": [
+            {
+              "expression": "strava_athlete_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "athletes_calendar_token_idx": {
+          "name": "athletes_calendar_token_idx",
+          "columns": [
+            {
+              "expression": "calendar_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.best_efforts": {
+      "name": "best_efforts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strava_effort_id": {
+          "name": "strava_effort_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elapsed_time": {
+          "name": "elapsed_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moving_time": {
+          "name": "moving_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_rank": {
+          "name": "pr_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "best_efforts_activity_id_idx": {
+          "name": "best_efforts_activity_id_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "best_efforts_activity_id_name_idx": {
+          "name": "best_efforts_activity_id_name_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "best_efforts_activity_id_activities_id_fk": {
+          "name": "best_efforts_activity_id_activities_id_fk",
+          "tableFrom": "best_efforts",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_subscriptions": {
+      "name": "calendar_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ical_url": {
+          "name": "ical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#64748b'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_subscriptions_athlete_idx": {
+          "name": "calendar_subscriptions_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_subscriptions_athlete_athletes_id_fk": {
+          "name": "calendar_subscriptions_athlete_athletes_id_fk",
+          "tableFrom": "calendar_subscriptions",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planned_trainings": {
+      "name": "planned_trainings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_date": {
+          "name": "planned_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport_type": {
+          "name": "sport_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "planned_training_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "structured_workout_id": {
+          "name": "structured_workout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_activity_id": {
+          "name": "linked_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "planned_trainings_athlete_idx": {
+          "name": "planned_trainings_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "planned_trainings_athlete_date_idx": {
+          "name": "planned_trainings_athlete_date_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "planned_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planned_trainings_athlete_athletes_id_fk": {
+          "name": "planned_trainings_athlete_athletes_id_fk",
+          "tableFrom": "planned_trainings",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "planned_trainings_structured_workout_id_structured_workouts_id_fk": {
+          "name": "planned_trainings_structured_workout_id_structured_workouts_id_fk",
+          "tableFrom": "planned_trainings",
+          "tableTo": "structured_workouts",
+          "columnsFrom": [
+            "structured_workout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "planned_trainings_linked_activity_id_activities_id_fk": {
+          "name": "planned_trainings_linked_activity_id_activities_id_fk",
+          "tableFrom": "planned_trainings",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "linked_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rider_settings": {
+      "name": "rider_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cd_a": {
+          "name": "cd_a",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crr": {
+          "name": "crr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bike_weight_kg": {
+          "name": "bike_weight_kg",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cycling_load_algorithm": {
+          "name": "cycling_load_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tss'"
+        },
+        "running_load_algorithm": {
+          "name": "running_load_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rtss'"
+        },
+        "swimming_load_algorithm": {
+          "name": "swimming_load_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stss'"
+        },
+        "initial_values": {
+          "name": "initial_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rider_settings_athlete_idx": {
+          "name": "rider_settings_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rider_settings_athlete_athletes_id_fk": {
+          "name": "rider_settings_athlete_athletes_id_fk",
+          "tableFrom": "rider_settings",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routes": {
+      "name": "routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport": {
+          "name": "sport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waypoints": {
+          "name": "waypoints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_polyline": {
+          "name": "map_polyline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elevation_gain": {
+          "name": "elevation_gain",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "routes_athlete_idx": {
+          "name": "routes_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routes_athlete_created_idx": {
+          "name": "routes_athlete_created_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routes_athlete_athletes_id_fk": {
+          "name": "routes_athlete_athletes_id_fk",
+          "tableFrom": "routes",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structured_workouts": {
+      "name": "structured_workouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sport": {
+          "name": "sport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bike'"
+        },
+        "structure": {
+          "name": "structure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_tss": {
+          "name": "estimated_tss",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ftp_at_save": {
+          "name": "ftp_at_save",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "structured_workouts_athlete_idx": {
+          "name": "structured_workouts_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_workouts_athlete_updated_idx": {
+          "name": "structured_workouts_athlete_updated_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structured_workouts_athlete_athletes_id_fk": {
+          "name": "structured_workouts_athlete_athletes_id_fk",
+          "tableFrom": "structured_workouts",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_jobs": {
+      "name": "sync_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activities_fetched": {
+          "name": "activities_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activities_pages_complete": {
+          "name": "activities_pages_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "streams_total": {
+          "name": "streams_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "streams_fetched": {
+          "name": "streams_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "sync_job_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sync_jobs_athlete_idx": {
+          "name": "sync_jobs_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_jobs_athlete_athletes_id_fk": {
+          "name": "sync_jobs_athlete_athletes_id_fk",
+          "tableFrom": "sync_jobs",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_periods": {
+      "name": "time_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport_types": {
+          "name": "sport_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "time_periods_athlete_idx": {
+          "name": "time_periods_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_periods_athlete_athletes_id_fk": {
+          "name": "time_periods_athlete_athletes_id_fk",
+          "tableFrom": "time_periods",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.planned_training_status": {
+      "name": "planned_training_status",
+      "schema": "public",
+      "values": [
+        "planned",
+        "completed"
+      ]
+    },
+    "public.sync_job_mode": {
+      "name": "sync_job_mode",
+      "schema": "public",
+      "values": [
+        "load_new",
+        "load_missing",
+        "reload_all",
+        "recompute_scores"
+      ]
+    },
+    "public.sync_job_status": {
+      "name": "sync_job_status",
+      "schema": "public",
+      "values": [
+        "fetching_activities",
+        "fetching_streams",
+        "computing_scores",
+        "completed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/server/db/migrations/meta/0021_snapshot.json
+++ b/src/server/db/migrations/meta/0021_snapshot.json
@@ -1,0 +1,1640 @@
+{
+  "id": "8c225317-2c98-4966-839e-cf26617c1dd1",
+  "prevId": "9a8576b2-19e2-421d-897c-fbcb3efe63cb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "strava_id": {
+          "name": "strava_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date_local": {
+          "name": "start_date_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_elevation_gain": {
+          "name": "total_elevation_gain",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_speed": {
+          "name": "average_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_watts": {
+          "name": "average_watts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_cadence": {
+          "name": "average_cadence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_heartrate": {
+          "name": "average_heartrate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_heartrate": {
+          "name": "max_heartrate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_speed": {
+          "name": "max_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_watts": {
+          "name": "max_watts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_average_watts": {
+          "name": "weighted_average_watts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilojoules": {
+          "name": "kilojoules",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moving_time": {
+          "name": "moving_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elapsed_time": {
+          "name": "elapsed_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_polyline": {
+          "name": "map_polyline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "are_streams_loaded": {
+          "name": "are_streams_loaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stream_fetch_attempts": {
+          "name": "stream_fetch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hrss": {
+          "name": "hrss",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tss": {
+          "name": "tss",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commute": {
+          "name": "commute",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perceived_exertion": {
+          "name": "perceived_exertion",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_note": {
+          "name": "private_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "power_bests": {
+          "name": "power_bests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_efforts": {
+          "name": "speed_efforts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "biggest_climb": {
+          "name": "biggest_climb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartrate_bests": {
+          "name": "heartrate_bests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "laps": {
+          "name": "laps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "are_best_efforts_loaded": {
+          "name": "are_best_efforts_loaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "best_effort_fetch_attempts": {
+          "name": "best_effort_fetch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "activities_strava_id_idx": {
+          "name": "activities_strava_id_idx",
+          "columns": [
+            {
+              "expression": "strava_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_athlete_idx": {
+          "name": "activities_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_athlete_id_idx": {
+          "name": "activities_athlete_id_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_athlete_start_date_idx": {
+          "name": "activities_athlete_start_date_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_athlete_streams_loaded_idx": {
+          "name": "activities_athlete_streams_loaded_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "are_streams_loaded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_athlete_best_efforts_idx": {
+          "name": "activities_athlete_best_efforts_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "are_best_efforts_loaded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activities_athlete_athletes_id_fk": {
+          "name": "activities_athlete_athletes_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_streams": {
+      "name": "activity_streams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_type": {
+          "name": "series_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_size": {
+          "name": "original_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_streams_activity_id_idx": {
+          "name": "activity_streams_activity_id_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_streams_activity_id_type_idx": {
+          "name": "activity_streams_activity_id_type_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_streams_activity_id_activities_id_fk": {
+          "name": "activity_streams_activity_id_activities_id_fk",
+          "tableFrom": "activity_streams",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.athlete_stats": {
+      "name": "athlete_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "athlete_stats_athlete_idx": {
+          "name": "athlete_stats_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "athlete_stats_athlete_athletes_id_fk": {
+          "name": "athlete_stats_athlete_athletes_id_fk",
+          "tableFrom": "athlete_stats",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.athletes": {
+      "name": "athletes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "strava_athlete_id": {
+          "name": "strava_athlete_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en-GB'"
+        },
+        "calendar_token": {
+          "name": "calendar_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_activity_id": {
+          "name": "last_seen_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "athletes_strava_id_idx": {
+          "name": "athletes_strava_id_idx",
+          "columns": [
+            {
+              "expression": "strava_athlete_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "athletes_calendar_token_idx": {
+          "name": "athletes_calendar_token_idx",
+          "columns": [
+            {
+              "expression": "calendar_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.best_efforts": {
+      "name": "best_efforts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strava_effort_id": {
+          "name": "strava_effort_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elapsed_time": {
+          "name": "elapsed_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moving_time": {
+          "name": "moving_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_rank": {
+          "name": "pr_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "best_efforts_activity_id_idx": {
+          "name": "best_efforts_activity_id_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "best_efforts_activity_id_name_idx": {
+          "name": "best_efforts_activity_id_name_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "best_efforts_activity_id_activities_id_fk": {
+          "name": "best_efforts_activity_id_activities_id_fk",
+          "tableFrom": "best_efforts",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_subscriptions": {
+      "name": "calendar_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ical_url": {
+          "name": "ical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#64748b'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_subscriptions_athlete_idx": {
+          "name": "calendar_subscriptions_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_subscriptions_athlete_athletes_id_fk": {
+          "name": "calendar_subscriptions_athlete_athletes_id_fk",
+          "tableFrom": "calendar_subscriptions",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planned_trainings": {
+      "name": "planned_trainings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_date": {
+          "name": "planned_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport_type": {
+          "name": "sport_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "planned_training_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "structured_workout_id": {
+          "name": "structured_workout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_activity_id": {
+          "name": "linked_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "planned_trainings_athlete_idx": {
+          "name": "planned_trainings_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "planned_trainings_athlete_date_idx": {
+          "name": "planned_trainings_athlete_date_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "planned_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planned_trainings_athlete_athletes_id_fk": {
+          "name": "planned_trainings_athlete_athletes_id_fk",
+          "tableFrom": "planned_trainings",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "planned_trainings_structured_workout_id_structured_workouts_id_fk": {
+          "name": "planned_trainings_structured_workout_id_structured_workouts_id_fk",
+          "tableFrom": "planned_trainings",
+          "tableTo": "structured_workouts",
+          "columnsFrom": [
+            "structured_workout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "planned_trainings_linked_activity_id_activities_id_fk": {
+          "name": "planned_trainings_linked_activity_id_activities_id_fk",
+          "tableFrom": "planned_trainings",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "linked_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rider_settings": {
+      "name": "rider_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cd_a": {
+          "name": "cd_a",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crr": {
+          "name": "crr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bike_weight_kg": {
+          "name": "bike_weight_kg",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cycling_load_algorithm": {
+          "name": "cycling_load_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tss'"
+        },
+        "running_load_algorithm": {
+          "name": "running_load_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rtss'"
+        },
+        "swimming_load_algorithm": {
+          "name": "swimming_load_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stss'"
+        },
+        "initial_values": {
+          "name": "initial_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rider_settings_athlete_idx": {
+          "name": "rider_settings_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rider_settings_athlete_athletes_id_fk": {
+          "name": "rider_settings_athlete_athletes_id_fk",
+          "tableFrom": "rider_settings",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routes": {
+      "name": "routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport": {
+          "name": "sport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waypoints": {
+          "name": "waypoints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_polyline": {
+          "name": "map_polyline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elevation_gain": {
+          "name": "elevation_gain",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "routes_athlete_idx": {
+          "name": "routes_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routes_athlete_created_idx": {
+          "name": "routes_athlete_created_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routes_athlete_athletes_id_fk": {
+          "name": "routes_athlete_athletes_id_fk",
+          "tableFrom": "routes",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structured_workouts": {
+      "name": "structured_workouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sport": {
+          "name": "sport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bike'"
+        },
+        "structure": {
+          "name": "structure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_tss": {
+          "name": "estimated_tss",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ftp_at_save": {
+          "name": "ftp_at_save",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "structured_workouts_athlete_idx": {
+          "name": "structured_workouts_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_workouts_athlete_updated_idx": {
+          "name": "structured_workouts_athlete_updated_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structured_workouts_athlete_athletes_id_fk": {
+          "name": "structured_workouts_athlete_athletes_id_fk",
+          "tableFrom": "structured_workouts",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_jobs": {
+      "name": "sync_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activities_fetched": {
+          "name": "activities_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activities_pages_complete": {
+          "name": "activities_pages_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "streams_total": {
+          "name": "streams_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "streams_fetched": {
+          "name": "streams_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "sync_job_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sync_jobs_athlete_idx": {
+          "name": "sync_jobs_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_jobs_athlete_athletes_id_fk": {
+          "name": "sync_jobs_athlete_athletes_id_fk",
+          "tableFrom": "sync_jobs",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_periods": {
+      "name": "time_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "athlete": {
+          "name": "athlete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport_types": {
+          "name": "sport_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "time_periods_athlete_idx": {
+          "name": "time_periods_athlete_idx",
+          "columns": [
+            {
+              "expression": "athlete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_periods_athlete_athletes_id_fk": {
+          "name": "time_periods_athlete_athletes_id_fk",
+          "tableFrom": "time_periods",
+          "tableTo": "athletes",
+          "columnsFrom": [
+            "athlete"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.planned_training_status": {
+      "name": "planned_training_status",
+      "schema": "public",
+      "values": [
+        "planned",
+        "completed"
+      ]
+    },
+    "public.sync_job_mode": {
+      "name": "sync_job_mode",
+      "schema": "public",
+      "values": [
+        "load_new",
+        "load_missing",
+        "reload_all",
+        "recompute_scores"
+      ]
+    },
+    "public.sync_job_status": {
+      "name": "sync_job_status",
+      "schema": "public",
+      "values": [
+        "fetching_activities",
+        "fetching_streams",
+        "computing_scores",
+        "completed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/server/db/migrations/meta/_journal.json
+++ b/src/server/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1785321412206,
       "tag": "0019_classy_khan",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1785338793355,
+      "tag": "0020_bizarre_shard",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/migrations/meta/_journal.json
+++ b/src/server/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1785338793355,
       "tag": "0020_bizarre_shard",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1785394149421,
+      "tag": "0021_handy_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -136,6 +136,11 @@ export const activities = pgTable(
   (t) => [
     uniqueIndex("activities_strava_id_idx").on(t.stravaId),
     index("activities_athlete_idx").on(t.athlete),
+    // Serves the `max(id) where athlete = ?` watermark probe behind the
+    // link-activity prompt, which runs on every app load. Without it that becomes
+    // an aggregate over every row the athlete owns (or a backwards walk of the
+    // primary key for any athlete whose newest rows aren't near the global max).
+    index("activities_athlete_id_idx").on(t.athlete, t.id),
     index("activities_athlete_start_date_idx").on(t.athlete, t.startDate),
     index("activities_athlete_streams_loaded_idx").on(
       t.athlete,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -56,6 +56,13 @@ export const athletes = pgTable(
     // Secret, unguessable token authenticating the athlete's iCal subscription
     // feed (`/api/calendar/{token}.ics`). Generated lazily, revocable.
     calendarToken: text("calendar_token"),
+    // Highest `activities.id` the athlete has already been offered a plan-link
+    // prompt for. Serial ids are monotonic per insert and sync/webhook upsert on
+    // `strava_id` (so a re-sync never mints new ones), which makes
+    // `id > lastSeenActivityId` an exact "imported since the last visit" test
+    // without a timestamp column on the huge `activities` table. Null = never
+    // computed; initialised lazily and silently on the first check.
+    lastSeenActivityId: integer("last_seen_activity_id"),
   },
   (t) => [
     uniqueIndex("athletes_strava_id_idx").on(t.stravaAthleteId),

--- a/src/server/trpc/routers/plannedTrainings.test.ts
+++ b/src/server/trpc/routers/plannedTrainings.test.ts
@@ -1,0 +1,213 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm/sql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { activities, athletes, plannedTrainings } from "../../db/schema";
+
+// The router pulls the db singleton, the validated env and the Strava client in
+// through `../index`; stub them so these cases exercise the watermark logic alone,
+// with no database and no environment.
+vi.mock("../../db", () => ({ db: dbMock }));
+vi.mock("../../env", () => ({ env: { APP_URL: undefined } }));
+vi.mock("../../lib/strava", () => ({
+  getAccessToken: vi.fn(),
+  updateActivityOnStrava: vi.fn(),
+  workoutTypeForSport: vi.fn(),
+}));
+vi.mock("../../../pages/api/auth/[...nextauth]", () => ({ authOptions: {} }));
+
+const ATHLETE_ID = 7;
+
+/** Rows the fake db hands back, set per test. */
+let athleteRow: { lastSeenActivityId: number | null } | undefined;
+let maxActivityId: number | null;
+let linkedRows: { id: number | null }[];
+let activityRows: Record<string, unknown>[];
+
+type Select = { fields: Record<string, unknown>; table: unknown; where: SQL };
+type Update = { table: unknown; values: Record<string, unknown>; where: SQL };
+let selects: Select[] = [];
+let updates: Update[] = [];
+
+/**
+ * Awaitable stand-in for a drizzle query-builder tail: both `await …where(x)` and
+ * `await …where(x).orderBy(y)` have to work.
+ */
+function thenable(rows: unknown[]) {
+  return {
+    orderBy: () => thenable(rows),
+    then: (resolve: (value: unknown) => void) => resolve(rows),
+  };
+}
+
+const dbMock = {
+  query: {
+    athletes: { findFirst: () => Promise.resolve(athleteRow) },
+  },
+  select: (fields: Record<string, unknown>) => ({
+    from: (table: unknown) => ({
+      where: (where: SQL) => {
+        selects.push({ fields, table, where });
+        if (table === plannedTrainings) {
+          return thenable(linkedRows);
+        }
+        if ("maxId" in fields) {
+          return thenable([{ maxId: maxActivityId }]);
+        }
+        return thenable(activityRows);
+      },
+    }),
+  }),
+  update: (table: unknown) => ({
+    set: (values: Record<string, unknown>) => ({
+      where: (where: SQL) => {
+        updates.push({ table, values, where });
+        return thenable([]);
+      },
+    }),
+  }),
+};
+
+const { plannedTrainingsRouter } = await import("./plannedTrainings");
+
+const dialect = new PgDialect();
+
+/** The SQL text + bound params of a captured drizzle condition or value. */
+function rendered(fragment: SQL) {
+  const query = dialect.sqlToQuery(fragment);
+  return { sql: query.sql, params: query.params };
+}
+
+function caller(athleteId = ATHLETE_ID) {
+  return plannedTrainingsRouter.createCaller({
+    db: dbMock as never,
+    session: {
+      user: {},
+      athleteId,
+      expires: "2100-01-01T00:00:00.000Z",
+    },
+    ip: "10.0.0.1",
+  });
+}
+
+beforeEach(() => {
+  athleteRow = { lastSeenActivityId: null };
+  maxActivityId = null;
+  linkedRows = [];
+  activityRows = [];
+  selects = [];
+  updates = [];
+});
+
+describe("newActivities", () => {
+  it("adopts the current maximum and reports nothing on the first ever call", async () => {
+    athleteRow = { lastSeenActivityId: null };
+    maxActivityId = 4211;
+
+    const result = await caller().newActivities({ athleteId: ATHLETE_ID });
+
+    expect(result).toEqual({ watermark: 4211, activities: [] });
+    // The whole point: an athlete with 4211 activities is not greeted with all of
+    // them the first time this ships.
+    expect(updates).toHaveLength(1);
+    expect(updates[0].table).toBe(athletes);
+    expect(updates[0].values).toEqual({ lastSeenActivityId: 4211 });
+    // No point querying for candidates it has already decided not to report.
+    expect(selects.some((s) => s.table === plannedTrainings)).toBe(false);
+  });
+
+  it("initialises to zero for an athlete with no activities yet", async () => {
+    athleteRow = { lastSeenActivityId: null };
+    maxActivityId = null;
+
+    const result = await caller().newActivities({ athleteId: ATHLETE_ID });
+
+    expect(result).toEqual({ watermark: 0, activities: [] });
+    expect(updates[0].values).toEqual({ lastSeenActivityId: 0 });
+  });
+
+  it("reports activities above the watermark without rewriting it", async () => {
+    athleteRow = { lastSeenActivityId: 100 };
+    maxActivityId = 103;
+    activityRows = [
+      {
+        id: 102,
+        stravaId: 999,
+        type: "Ride",
+        name: "Evening Ride",
+        startDateLocal: "2026-03-04T18:00:00",
+      },
+    ];
+
+    const result = await caller().newActivities({ athleteId: ATHLETE_ID });
+
+    expect(result).toEqual({ watermark: 103, activities: activityRows });
+    // Only `acknowledgeNewActivities` may move the watermark; a plain read that
+    // advanced it would swallow the batch before the athlete ever saw it.
+    expect(updates).toEqual([]);
+  });
+
+  it("excludes activities already linked to a plan", async () => {
+    athleteRow = { lastSeenActivityId: 100 };
+    maxActivityId = 103;
+    linkedRows = [{ id: 101 }, { id: null }];
+
+    await caller().newActivities({ athleteId: ATHLETE_ID });
+
+    const candidates = selects.find(
+      (s) => s.table === activities && !("maxId" in s.fields),
+    );
+    const where = rendered(candidates!.where);
+    expect(where.sql).toContain("not in");
+    // The null `linkedActivityId` is filtered out rather than reaching the query.
+    expect(where.params).toContain(101);
+    expect(where.params).not.toContain(null);
+  });
+
+  it("omits the exclusion clause when nothing is linked", async () => {
+    athleteRow = { lastSeenActivityId: 100 };
+    maxActivityId = 103;
+    linkedRows = [];
+
+    await caller().newActivities({ athleteId: ATHLETE_ID });
+
+    const candidates = selects.find(
+      (s) => s.table === activities && !("maxId" in s.fields),
+    );
+    expect(rendered(candidates!.where).sql).not.toContain("not in");
+  });
+
+  it("rejects a mismatched athlete", async () => {
+    await expect(
+      caller(ATHLETE_ID + 1).newActivities({ athleteId: ATHLETE_ID }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("acknowledgeNewActivities", () => {
+  it("clamps the watermark forward, never back", async () => {
+    await caller().acknowledgeNewActivities({
+      athleteId: ATHLETE_ID,
+      watermark: 120,
+    });
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0].table).toBe(athletes);
+    const value = rendered(updates[0].values.lastSeenActivityId as SQL);
+    // A stale in-flight acknowledgement must not rewind a watermark a later one
+    // already moved forward, and a null column must not poison the comparison.
+    expect(value.sql).toContain("greatest");
+    expect(value.sql).toContain("coalesce");
+    expect(value.params).toContain(120);
+  });
+
+  it("rejects a mismatched athlete", async () => {
+    await expect(
+      caller(ATHLETE_ID + 1).acknowledgeNewActivities({
+        athleteId: ATHLETE_ID,
+        watermark: 1,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(updates).toEqual([]);
+  });
+});

--- a/src/server/trpc/routers/plannedTrainings.ts
+++ b/src/server/trpc/routers/plannedTrainings.ts
@@ -1,9 +1,21 @@
-import { and, asc, eq, gte, isNotNull, lte } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  gt,
+  gte,
+  isNotNull,
+  lte,
+  max,
+  notInArray,
+  sql,
+} from "drizzle-orm";
 import { randomBytes } from "node:crypto";
 import { z } from "zod";
 
 import { TRPCError } from "@trpc/server";
 
+import type { Database } from "../../db";
 import { activities, athletes, plannedTrainings } from "../../db/schema";
 import { env } from "../../env";
 import {
@@ -28,6 +40,26 @@ const trainingFields = {
 /** Build the absolute iCal feed URL when the public origin is configured. */
 function buildFeedUrl(token: string): string | null {
   return env.APP_URL ? `${env.APP_URL}/api/calendar/${token}.ics` : null;
+}
+
+/**
+ * Internal `activities.id`s already reconciled with a plan, so an activity is
+ * never offered — nor auto-suggested — for a second one.
+ */
+async function getLinkedActivityIds(
+  db: Database,
+  athleteId: number,
+): Promise<number[]> {
+  const rows = await db
+    .select({ id: plannedTrainings.linkedActivityId })
+    .from(plannedTrainings)
+    .where(
+      and(
+        eq(plannedTrainings.athlete, athleteId),
+        isNotNull(plannedTrainings.linkedActivityId),
+      ),
+    );
+  return rows.map((r) => r.id).filter((id): id is number => id != null);
 }
 
 export const plannedTrainingsRouter = router({
@@ -67,17 +99,89 @@ export const plannedTrainingsRouter = router({
   linkedActivityIds: protectedProcedure
     .input(z.object({ athleteId: z.number() }))
     .use(validateAthleteOwnership)
+    .query(({ ctx, input }) => getLinkedActivityIds(ctx.db, input.athleteId)),
+
+  /**
+   * Activities imported since the athlete last had the link prompt shown to
+   * them, as the raw candidate set for that prompt — the day/sport matching runs
+   * on the client, because `~/utils/sportConfig` pulls in `lucide-react` icons
+   * and has no business in the server bundle.
+   *
+   * `activities.id` is a serial and both the backfill sync and the webhook
+   * upsert on `strava_id`, so a re-sync never mints new ids: `id > watermark` is
+   * an exact "imported since the last visit" test.
+   *
+   * The first ever call has no watermark to compare against, so it silently
+   * adopts the current maximum and reports nothing new — otherwise every athlete
+   * would be greeted with their entire history the first time they load the app
+   * after this ships. Writing from a query mirrors the lazy `calendarToken`
+   * creation in `getCalendarToken` below.
+   */
+  newActivities: protectedProcedure
+    .input(z.object({ athleteId: z.number() }))
+    .use(validateAthleteOwnership)
     .query(async ({ ctx, input }) => {
+      const athlete = await ctx.db.query.athletes.findFirst({
+        where: eq(athletes.id, input.athleteId),
+      });
+      if (!athlete) {
+        throw new TRPCError({ code: "NOT_FOUND" });
+      }
+
+      const [maxRow] = await ctx.db
+        .select({ maxId: max(activities.id) })
+        .from(activities)
+        .where(eq(activities.athlete, input.athleteId));
+      const watermark = maxRow?.maxId ?? 0;
+
+      if (athlete.lastSeenActivityId == null) {
+        await ctx.db
+          .update(athletes)
+          .set({ lastSeenActivityId: watermark })
+          .where(eq(athletes.id, input.athleteId));
+        return { watermark, activities: [] };
+      }
+
+      const linked = await getLinkedActivityIds(ctx.db, input.athleteId);
+      const conditions = [
+        eq(activities.athlete, input.athleteId),
+        gt(activities.id, athlete.lastSeenActivityId),
+      ];
+      if (linked.length > 0) {
+        conditions.push(notInArray(activities.id, linked));
+      }
+
       const rows = await ctx.db
-        .select({ id: plannedTrainings.linkedActivityId })
-        .from(plannedTrainings)
-        .where(
-          and(
-            eq(plannedTrainings.athlete, input.athleteId),
-            isNotNull(plannedTrainings.linkedActivityId),
-          ),
-        );
-      return rows.map((r) => r.id).filter((id): id is number => id != null);
+        .select({
+          id: activities.id,
+          stravaId: activities.stravaId,
+          type: activities.type,
+          name: activities.name,
+          startDateLocal: activities.startDateLocal,
+        })
+        .from(activities)
+        .where(and(...conditions))
+        .orderBy(asc(activities.startDateLocal));
+
+      return { watermark, activities: rows };
+    }),
+
+  /**
+   * Records that the athlete has been shown the link prompt for everything up to
+   * `watermark`, so it doesn't come back on the next load. `greatest` keeps a
+   * stale in-flight acknowledgement from rewinding a watermark a later one moved
+   * forward.
+   */
+  acknowledgeNewActivities: protectedProcedure
+    .input(z.object({ athleteId: z.number(), watermark: z.number().int() }))
+    .use(validateAthleteOwnership)
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db
+        .update(athletes)
+        .set({
+          lastSeenActivityId: sql`greatest(coalesce(${athletes.lastSeenActivityId}, 0), ${input.watermark})`,
+        })
+        .where(eq(athletes.id, input.athleteId));
     }),
 
   create: protectedProcedure

--- a/src/server/trpc/routers/plannedTrainings.ts
+++ b/src/server/trpc/routers/plannedTrainings.ts
@@ -123,6 +123,7 @@ export const plannedTrainingsRouter = router({
     .query(async ({ ctx, input }) => {
       const athlete = await ctx.db.query.athletes.findFirst({
         where: eq(athletes.id, input.athleteId),
+        columns: { lastSeenActivityId: true },
       });
       if (!athlete) {
         throw new TRPCError({ code: "NOT_FOUND" });
@@ -278,6 +279,25 @@ export const plannedTrainingsRouter = router({
       });
       if (!activity) {
         throw new TRPCError({ code: "NOT_FOUND" });
+      }
+
+      // One activity fulfils at most one plan. The pickers filter on
+      // `linkedActivityIds`, but that's a cached client-side list — enforce the
+      // invariant here too, before renaming anything on Strava, or a stale cache
+      // silently overwrites the first plan's title and leaves two plans claiming
+      // the same activity.
+      const claimedBy = await ctx.db.query.plannedTrainings.findFirst({
+        where: and(
+          eq(plannedTrainings.athlete, input.athleteId),
+          eq(plannedTrainings.linkedActivityId, activity.id),
+        ),
+        columns: { id: true },
+      });
+      if (claimedBy) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "This activity is already linked to a planned training.",
+        });
       }
 
       const accessToken = await getAccessToken(ctx.db, input.athleteId);


### PR DESCRIPTION
## Context

Reconciling a planned training with the Strava activity that fulfilled it was entirely manual: open the Journal, click the plan, pick the activity from the Mark done combobox. Nothing surfaced a waiting match, so plans piled up as `planned` even when the matching ride was already in the database — the webhook usually imports it long before you next open the site.

Now, when the app loads and an activity imported since your last visit perfectly matches a planned training, a dialog (bottom drawer on mobile) offers to link them.

| Desktop | Mobile |
| --- | --- |
| Centred dialog | Bottom drawer, full width |

## How it works

**The match rule** is the Journal's own notion of a "Perfect match" — same calendar day, same sport *category* (so a `VirtualRide` fulfils a planned `Ride`). It moved into `perfectMatch.ts` and the Mark done picker now calls it too, so the two can't drift apart.

**Linking** goes through the existing `plannedTrainings.markDone`, unchanged — including the rename hint, since it renames the activity on Strava and flags it as a workout.

**"Since the last visit"** is a per-athlete `athletes.lastSeenActivityId` watermark rather than a timestamp. `activities.id` is a serial and both the backfill sync and the webhook upsert on `strava_id`, so a re-sync never mints new ids and `id > watermark` is an exact "imported since" test — no timestamp column on the very large `activities` table. It initialises lazily and silently, so nobody is greeted with their entire history the first time they load this. Server-side, so you're asked once and not once per device.

**Pairing is greedy and strictly 1:1.** Linking is destructive and an activity must never be claimed by two plans, so an ambiguous day (two plans, two matching rides) yields one pairing per plan rather than a guess among the alternatives. Leftovers stay reachable from the Journal's Mark done picker — which is also where anything dismissed here goes, since closing the prompt by any route (Link, Not now, Escape, backdrop) acknowledges the whole batch. Asking once beats nagging on every load.

## Verified

Driven against the running app with Playwright, plus 10 unit tests on the pairing logic.

- Lazy init: a NULL watermark silently adopted `max(activities.id)` and showed nothing.
- With the watermark rolled back and three seeded plans, the prompt offered exactly the two real pairs — a Swim plan with no new swim activity, and a WeightTraining activity with no matching plan, were both correctly left out.
- Mobile at 390×844 renders as a full-width bottom drawer; desktop as a centred dialog.
- "Not now" advanced the watermark; a reload showed no prompt.
- The Link button's request was intercepted and **aborted** rather than let through — it renames a real activity on a real Strava account. The aborted request confirmed the payload (correct plan ↔ activity pair) and the failure path, which shows the error and keeps the dialog open.

One deviation from the plan: the plan duration renders with `formatCompactDuration(…, { subHour: "min" })` ("45min", "2h00") to match `plannedBlock`, rather than `formatElapsed` ("45:00"), which read like a stopwatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)